### PR TITLE
Make option 'main' accept an array

### DIFF
--- a/lib/less-renderer.coffee
+++ b/lib/less-renderer.coffee
@@ -44,7 +44,12 @@ module.exports =
             options = @parseFirstLine filepath, line
 
             if options.main
-                @getOptions path.resolve(path.dirname(filepath), options.main), callback
+                if typeof options.main == 'string'
+                    @getOptions path.resolve(path.dirname(filepath), options.main), callback
+                else
+                    for i in [0...options.main.length]
+                        @getOptions path.resolve(path.dirname(filepath), options.main[i]), callback
+
             else
                 callback options
 


### PR DESCRIPTION
I needed to be able to compile both production and development versions from parly the same source files that are modified all the time. In my case if would've been more efficient to allow both 'out' and 'main' simultaneously to allow an additional layer of variable overrides and such, but this was faster to do.
