### PR TITLE
Fix for Atom 1.4

### DIFF
--- a/lib/atom-less.coffee
+++ b/lib/atom-less.coffee
@@ -19,7 +19,7 @@ module.exports =
         return if not editor
 
         grammer = editor.getGrammar()
-        return if grammer.name != 'LESS'
+        return if grammer.name != 'Less'
 
         filepath = editor.getPath()
         renderer.render filepath


### PR DESCRIPTION
Less don't use LESS capitalised anymore and Atom 1.4 reflected that change.  The plugin would not run as it would not detect the file type in Atom anymore.
