### PR TITLE
Onsave messge switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ On the first line of LESS files, add a valid JSON comment, not including the out
     a string specifying the 'compatibility' property, or an object specifying the Clean-CSS properties (not compatible with Source Maps)
 - **"autoprefix"**: <code>string|object</code> -
     a string specifying the 'browsers' property, or an object specifying the AutoPrefixer properties
+- **"onSaveMessage"**: <code>boolean</code> -
+    <code>true</code> to enable messages (`File created`) on file saving.
 
 Other LESS compiler options might work but are untested at this point.
 

--- a/lib/output-writer.coffee
+++ b/lib/output-writer.coffee
@@ -5,8 +5,7 @@ async = require 'async'
 
 class OutputWriter
     write: (output, options) ->
-        [cssFile, sourceMapFile] = @getDestination options
-
+        [cssFile, sourceMapFile, onSaveMessage] = @getDestination options
         async.series
             css: (callback) =>
                 @writeFile cssFile, output.css, callback
@@ -19,10 +18,11 @@ class OutputWriter
                 if err
                     atom.notifications.addError err,
                         dismissiable: true
-                else if output.map?
-                    atom.notifications.addSuccess "Files created"
-                else
-                    atom.notifications.addSuccess "File created"
+                else if onSaveMessage
+                        if output.map?
+                            atom.notifications.addSuccess "Files created"
+                        else
+                            atom.notifications.addSuccess "File created"
 
     writeFile: (file, content, callback) ->
         mkdirp path.dirname(file), (err) ->
@@ -47,6 +47,6 @@ class OutputWriter
             sourceMapFile = "#{cssFile}.map"
             sourceMapFile = path.resolve lessDir, sourceMapFile
 
-        return [cssFile, sourceMapFile]
+        return [cssFile, sourceMapFile, options.onSaveMessage]
 
 module.exports = new OutputWriter


### PR DESCRIPTION
Disabled verbose on saving messages, set `onSaveMessage` to enable.

example:

```js
//"out": "main.css", "onSaveMessage": true

@import "component.less";

html, body {
    height: 100%;
}
```